### PR TITLE
Status code listings for endpoints

### DIFF
--- a/serv.cabal
+++ b/serv.cabal
@@ -16,35 +16,36 @@ library
   hs-source-dirs:      src
   exposed-modules:
 
-    Serv.Api.Annotation
     Serv.Api
+    Serv.Api.Annotation
     Serv.Common
     Serv.ContentType
     Serv.Cors
     Serv.Header
+    Serv.Internal.Api
     Serv.Internal.Api.Analysis
     Serv.Internal.Api.Annotation
-    Serv.Internal.Api
     Serv.Internal.Cors
-    Serv.Internal.Header.Serialization
     Serv.Internal.Header
+    Serv.Internal.Header.Serialization
     Serv.Internal.MediaType
     Serv.Internal.Pair
     Serv.Internal.Query
     Serv.Internal.RawText
     Serv.Internal.Rec
+    Serv.Internal.Server
     Serv.Internal.Server.Config
     Serv.Internal.Server.Context
     Serv.Internal.Server.Error
     Serv.Internal.Server.Monad
     Serv.Internal.Server.Response
     Serv.Internal.Server.Type
-    Serv.Internal.Server
     Serv.Internal.StatusCode
     Serv.Internal.TypeLevel
     Serv.Internal.URI
     Serv.Internal.Verb
     Serv.Server
+    Serv.StatusCode
     Serv.URI
 
   build-depends:       base >= 4.7 && < 5

--- a/serv.cabal
+++ b/serv.cabal
@@ -40,6 +40,7 @@ library
     Serv.Internal.Server.Response
     Serv.Internal.Server.Type
     Serv.Internal.Server
+    Serv.Internal.StatusCode
     Serv.Internal.TypeLevel
     Serv.Internal.URI
     Serv.Internal.Verb

--- a/src/Serv/Api.hs
+++ b/src/Serv/Api.hs
@@ -9,6 +9,8 @@ module Serv.Api (
 
   , Handler (..)
   , Method, CaptureBody, CaptureHeaders, CaptureQuery
+  , Alternative (..)
+  , Responding
 
   , Body (..)
   , HasBody, Empty

--- a/src/Serv/Api.hs
+++ b/src/Serv/Api.hs
@@ -9,8 +9,8 @@ module Serv.Api (
 
   , Handler (..)
   , Method, CaptureBody, CaptureHeaders, CaptureQuery
-  , Alternative (..)
-  , Responding
+  , Output (..)
+  , Respond
 
   , Body (..)
   , HasBody, Empty

--- a/src/Serv/Internal/Api.hs
+++ b/src/Serv/Internal/Api.hs
@@ -35,13 +35,11 @@ type Empty = 'Empty
 
 singletons
   [d|
-    data Alternative nat symbol star where
-      Responding
-        :: StatusCode nat -> [ (HeaderType symbol, star) ] -> Body star
-        -> Responding nat symbol star
+    data Output symbol star where
+      Respond :: [ (HeaderType symbol, star) ] -> Body star -> Output symbol star
   |]
 
-type Responding code hdrs body = 'Responding code hdrs body
+type Respond hdrs body = 'Respond hdrs body
 
 -- | A 'Handler' is a single HTTP verb response handled at a given 'Endpoint'.
 -- In order to complete a 'Handler''s operation it may demand data from the
@@ -58,7 +56,7 @@ type Responding code hdrs body = 'Responding code hdrs body
 singletons
   [d|
     data Handler nat symbol star where
-      Method :: Verb -> [Alternative nat symbol star] -> Handler nat symbol star
+      Method :: Verb -> [ (StatusCode nat, Output symbol star) ] -> Handler nat symbol star
       CaptureBody :: [star] -> star -> Handler nat symbol star -> Handler nat symbol star
       CaptureHeaders :: [ (HeaderType symbol, star) ] -> Handler nat symbol star -> Handler nat symbol star
       CaptureQuery :: [ (symbol, star) ] -> Handler nat symbol star -> Handler nat symbol star

--- a/src/Serv/Internal/Api.hs
+++ b/src/Serv/Internal/Api.hs
@@ -14,6 +14,7 @@ module Serv.Internal.Api where
 
 import           Data.Singletons.TH
 import           Serv.Internal.Header (HeaderType)
+import           Serv.Internal.StatusCode (StatusCode)
 import           Serv.Internal.Verb
 
 -- | 'Handler' responses may opt to include a response body or not.
@@ -32,6 +33,18 @@ singletons
 type HasBody ctypes ty = 'HasBody ctypes ty
 type Empty = 'Empty
 
+singletons
+  [d|
+    data Alternative nat symbol star where
+      Responding
+        :: StatusCode nat -> [ (HeaderType symbol, star) ] -> Body star
+        -> Responding nat symbol star
+  |]
+
+type Responding code hdrs body = 'Responding code hdrs body
+
+-- type Responding code hdrs body = 'Responding code hdrs body
+
 -- | A 'Handler' is a single HTTP verb response handled at a given 'Endpoint'.
 -- In order to complete a 'Handler''s operation it may demand data from the
 -- request such as headers or the request body.
@@ -46,14 +59,14 @@ type Empty = 'Empty
 --
 singletons
   [d|
-    data Handler symbol star where
-      Method :: Verb -> [ (HeaderType symbol, star) ] -> Body star -> Handler symbol star
-      CaptureBody :: [star] -> star -> Handler symbol star -> Handler symbol star
-      CaptureHeaders :: [ (HeaderType symbol, star) ] -> Handler symbol star -> Handler symbol star
-      CaptureQuery :: [ (symbol, star) ] -> Handler symbol star -> Handler symbol star
+    data Handler nat symbol star where
+      Method :: Verb -> [Alternative nat symbol star] -> Handler nat symbol star
+      CaptureBody :: [star] -> star -> Handler nat symbol star -> Handler nat symbol star
+      CaptureHeaders :: [ (HeaderType symbol, star) ] -> Handler nat symbol star -> Handler nat symbol star
+      CaptureQuery :: [ (symbol, star) ] -> Handler nat symbol star -> Handler nat symbol star
   |]
 
-type Method verb responseHeaders body = 'Method verb responseHeaders body
+type Method verb responses = 'Method verb responses
 type CaptureBody cTypes ty method = 'CaptureBody cTypes ty method
 type CaptureHeaders hdrs method = 'CaptureHeaders hdrs method
 type CaptureQuery query method = 'CaptureQuery query method
@@ -115,11 +128,11 @@ type Cors ty = 'Cors ty
 
 singletons
   [d|
-    data Api symbol star where
-      Endpoint :: star -> [Handler symbol star] -> Api symbol star
-      OneOf :: [Api symbol star] -> Api symbol star
-      Raw :: Api symbol star
-      (:>) :: Path symbol star -> Api symbol star -> Api symbol star
+    data Api nat symbol star where
+      Endpoint :: star -> [Handler nat symbol star] -> Api nat symbol star
+      OneOf :: [Api nat symbol star] -> Api nat symbol star
+      Raw :: Api nat symbol star
+      (:>) :: Path symbol star -> Api nat symbol star -> Api nat symbol star
   |]
 
 type Endpoint ann ms = 'Endpoint ann ms

--- a/src/Serv/Internal/Api.hs
+++ b/src/Serv/Internal/Api.hs
@@ -43,8 +43,6 @@ singletons
 
 type Responding code hdrs body = 'Responding code hdrs body
 
--- type Responding code hdrs body = 'Responding code hdrs body
-
 -- | A 'Handler' is a single HTTP verb response handled at a given 'Endpoint'.
 -- In order to complete a 'Handler''s operation it may demand data from the
 -- request such as headers or the request body.

--- a/src/Serv/Internal/Api/Analysis.hs
+++ b/src/Serv/Internal/Api/Analysis.hs
@@ -54,12 +54,12 @@ inspectHandler s =
     SMethod sVerb sResponses ->
       case sResponses of
         SNil -> mempty
-        SCons (SResponding _sCode sHdrs _sBody) sTail ->
+        SCons (STuple2 _sCode (SRespond sHdrs _sBody)) sRest ->
           EndpointAnalysis
           { verbsHandled = Set.singleton (fromSing sVerb)
           , headersEmitted = headerNames sHdrs
           , headersExpected = Set.empty
-          } <> inspectHandler (SMethod sVerb sTail)
+          } <> inspectHandler (SMethod sVerb sRest)
     SCaptureHeaders sHdrs sNext ->
       EndpointAnalysis
       { verbsHandled = Set.empty

--- a/src/Serv/Internal/Api/Analysis.hs
+++ b/src/Serv/Internal/Api/Analysis.hs
@@ -40,23 +40,26 @@ instance Monoid EndpointAnalysis where
     , headersEmitted = headersEmitted ea <> headersEmitted eb
     }
 
-inspectEndpoint :: forall (hs :: [Handler Symbol *]) . Sing hs -> EndpointAnalysis
+inspectEndpoint :: forall (hs :: [Handler Nat Symbol *]) . Sing hs -> EndpointAnalysis
 inspectEndpoint s =
   case s of
     SNil -> mempty
     SCons sHandler sRest -> inspectHandler sHandler <> inspectEndpoint sRest
 
-inspectHandler :: forall (h :: Handler Symbol *) . Sing h -> EndpointAnalysis
+inspectHandler :: forall (h :: Handler Nat Symbol *) . Sing h -> EndpointAnalysis
 inspectHandler s =
   case s of
     SCaptureQuery _ sNext -> inspectHandler sNext
     SCaptureBody _ _ sNext -> inspectHandler sNext
-    SMethod sVerb sHdrs _sBody ->
-      EndpointAnalysis
-      { verbsHandled = Set.singleton (fromSing sVerb)
-      , headersEmitted = headerNames sHdrs
-      , headersExpected = Set.empty
-      }
+    SMethod sVerb sResponses ->
+      case sResponses of
+        SNil -> mempty
+        SCons (SResponding _sCode sHdrs _sBody) sTail ->
+          EndpointAnalysis
+          { verbsHandled = Set.singleton (fromSing sVerb)
+          , headersEmitted = headerNames sHdrs
+          , headersExpected = Set.empty
+          } <> inspectHandler (SMethod sVerb sTail)
     SCaptureHeaders sHdrs sNext ->
       EndpointAnalysis
       { verbsHandled = Set.empty
@@ -72,8 +75,8 @@ headerNames s =
     SCons (STuple2 sHt _sTy) sRest ->
       Set.insert (Header.headerType sHt) (headerNames sRest)
 
-inspectVerbs :: forall (hs :: [Handler Symbol *]) . Sing hs -> Set Verb
+inspectVerbs :: forall (hs :: [Handler Nat Symbol *]) . Sing hs -> Set Verb
 inspectVerbs = verbsHandled . inspectEndpoint
 
-headersExpectedOf :: forall (hs :: [Handler Symbol *]) . Sing hs -> Set (HeaderType Text)
+headersExpectedOf :: forall (hs :: [Handler Nat Symbol *]) . Sing hs -> Set (HeaderType Text)
 headersExpectedOf = headersExpected . inspectEndpoint

--- a/src/Serv/Internal/Server/Context.hs
+++ b/src/Serv/Internal/Server/Context.hs
@@ -60,7 +60,7 @@ hush :: Either e a -> Maybe a
 hush = either (const Nothing) Just
 
 corsHeaders
-  :: forall (hs :: [Handler Symbol *])
+  :: forall (hs :: [Handler Nat Symbol *])
   . Sing hs -> Cors.IncludeMethods -> Context -> Maybe [HTTP.Header]
 corsHeaders s includeMethods ctx = do
   let ana = Analysis.inspectEndpoint s

--- a/src/Serv/Internal/Server/Monad.hs
+++ b/src/Serv/Internal/Server/Monad.hs
@@ -76,7 +76,7 @@ expectHeader :: forall m (n :: HeaderType Symbol) . Monad m => Sing n -> Text ->
 expectHeader s value = state (swap . Ctx.expectHeader s value)
 
 corsHeaders
-  :: forall m (hs :: [Handler Symbol *])
+  :: forall m (hs :: [Handler Nat Symbol *])
   . Monad m => Sing hs -> Cors.IncludeMethods -> InContext m (Maybe [HTTP.Header])
 corsHeaders s incl = do
   ctx <- get

--- a/src/Serv/Internal/Server/Response.hs
+++ b/src/Serv/Internal/Server/Response.hs
@@ -2,113 +2,109 @@
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module Serv.Internal.Server.Response where
 
-import qualified Data.ByteString.Lazy                    as Sl
+import qualified Data.ByteString.Lazy               as Sl
 import           Data.Function                      ((&))
 import           Data.Singletons
+import           Data.Singletons.Prelude.List
 import           GHC.TypeLits
 import qualified Network.HTTP.Types                 as HTTP
 import           Serv.Internal.Api
 import           Serv.Internal.Header
 import           Serv.Internal.Header.Serialization
 import           Serv.Internal.Pair
-import           Serv.Internal.Rec
-
-data ResponseType = Ok | NonStandard
-
-type Ok = 'Ok
-type NonStandard = 'NonStandard
+import           Serv.Internal.Rec                  (Rec)
+import qualified Serv.Internal.Rec                  as Rec
+import           Serv.Internal.StatusCode           (StatusCode)
 
 -- | Responses generated in 'Server' implementations.
-data Response (ty :: ResponseType) (headers :: [ (HeaderType Symbol, *) ]) body where
-  Response
-    :: HTTP.Status
-    -> [HTTP.Header]
-    -> Rec headers
-    -> a
-    -> Response Ok headers ('HasBody ctypes a)
+data Response (status :: StatusCode Nat) (headers :: [ (HeaderType Symbol, *) ]) body where
+  ContentResponse
+    :: [HTTP.Header] -> Rec headers -> a
+    -> Response status headers ('HasBody ctypes a)
   EmptyResponse
-    :: HTTP.Status
-    -> [HTTP.Header]
-    -> Rec headers
-    -> Response Ok headers 'Empty
-  ErrorResponse
-    :: HTTP.Status
-    -> [HTTP.Header]
-    -> Maybe Sl.ByteString
-    -> Response NonStandard headers body
+    :: [HTTP.Header] -> Rec headers
+    -> Response status headers 'Empty
 
--- | Papers over the distinction between standard and non-standard responses.
-data AResponse headers body where
-  AResponse :: Response e headers body -> AResponse headers body
+data SomeResponse (alts :: [Alternative Nat Symbol *]) where
+  StandardResponse
+    :: Elem (Responding code hdrs body) alts ~ True
+    => Response code hdrs body
+    -> SomeResponse alts
+  NonStandardResponse
+    :: HTTP.Status -> [HTTP.Header] -> Maybe Sl.ByteString
+    -> SomeResponse alts
 
-respond :: Monad m => Response e headers body -> m (AResponse headers body)
-respond = return . AResponse
+respond
+  :: (Elem (Responding code hdrs body) alts ~ True, Monad m)
+  => Response code hdrs body -> m (SomeResponse alts)
+respond = return . StandardResponse
 
--- An 'emptyResponse' returns the provided status message with no body or headers
-emptyResponse :: HTTP.Status -> Response Ok '[] 'Empty
-emptyResponse status = EmptyResponse status [] Nil
-
--- | Adds a body to a response
-withBody
-  :: a -> Response Ok headers 'Empty -> Response Ok headers ('HasBody ctypes a)
-withBody a (EmptyResponse status secretHeaders headers) =
-  Response status secretHeaders headers a
-
--- | Adds a header to a response
-withHeader
-  :: Sing name -> value
-  -> Response Ok headers body -> Response Ok (name ::: value ': headers) body
-withHeader s val r = case r of
-  Response status secretHeaders headers body ->
-    Response status secretHeaders (headers & s -: val) body
-  EmptyResponse status secretHeaders headers ->
-    EmptyResponse status secretHeaders (headers & s -: val)
-
--- | Unlike 'withHeader', 'withQuietHeader' allows you to add headers
--- not explicitly specified in the api specification.
-withQuietHeader
-  :: HeaderEncode name value
-     => Sing name -> value
-     -> Response e headers body -> Response e headers body
-withQuietHeader s value r =
-  case headerPair s value of
-    Nothing -> r
-    Just newHeader ->
-      case r of
-        Response status secretHeaders headers body ->
-          Response status (newHeader : secretHeaders) headers body
-        EmptyResponse status secretHeaders headers ->
-          EmptyResponse status (newHeader : secretHeaders) headers
-        ErrorResponse status headers body ->
-          ErrorResponse status (newHeader : headers) body
-
--- | Construct a response in the event of an error. These are /not/ tracked
--- by the API type and are therefore free to return whatever they like.
-errorResponse :: HTTP.Status -> [HTTP.Header] -> Maybe Sl.ByteString -> Response NonStandard h b
-errorResponse = ErrorResponse
-
--- | If a response type is complete defined by its implementation then
--- applying 'resorted' to it will future proof it against reorderings
--- of headers. If the response type is not completely inferrable, however,
--- then this will require manual annotations of the "pre-sorted" response.
-resortHeaders :: RecordIso headers headers' => Response e headers body -> Response e headers' body
-resortHeaders r =
-  case r of
-    Response status secretHeaders headers body ->
-      Response status secretHeaders (reorder headers) body
-    EmptyResponse status secretHeaders headers ->
-      EmptyResponse status secretHeaders (reorder headers)
-    ErrorResponse s h b -> ErrorResponse s h b
-
--- | Used primarily for implementing @HEAD@ request automatically.
-deleteBody :: Response e headers body -> Response e headers 'Empty
-deleteBody r =
-  case r of
-    Response status secretHeaders headers _ ->
-      EmptyResponse status secretHeaders headers
-    EmptyResponse{} -> r
-    ErrorResponse s h _ -> ErrorResponse s h Nothing
+-- -- An 'emptyResponse' returns the provided status message with no body or headers
+-- emptyResponse :: HTTP.Status -> Response Ok '[] 'Empty
+-- emptyResponse status = EmptyResponse status [] Nil
+--
+-- -- | Adds a body to a response
+-- withBody
+--   :: a -> Response Ok headers 'Empty -> Response Ok headers ('HasBody ctypes a)
+-- withBody a (EmptyResponse status secretHeaders headers) =
+--   Response status secretHeaders headers a
+--
+-- -- | Adds a header to a response
+-- withHeader
+--   :: Sing name -> value
+--   -> Response Ok headers body -> Response Ok (name ::: value ': headers) body
+-- withHeader s val r = case r of
+--   Response status secretHeaders headers body ->
+--     Response status secretHeaders (headers & s -: val) body
+--   EmptyResponse status secretHeaders headers ->
+--     EmptyResponse status secretHeaders (headers & s -: val)
+--
+-- -- | Unlike 'withHeader', 'withQuietHeader' allows you to add headers
+-- -- not explicitly specified in the api specification.
+-- withQuietHeader
+--   :: HeaderEncode name value
+--      => Sing name -> value
+--      -> Response e headers body -> Response e headers body
+-- withQuietHeader s value r =
+--   case headerPair s value of
+--     Nothing -> r
+--     Just newHeader ->
+--       case r of
+--         Response status secretHeaders headers body ->
+--           Response status (newHeader : secretHeaders) headers body
+--         EmptyResponse status secretHeaders headers ->
+--           EmptyResponse status (newHeader : secretHeaders) headers
+--         ErrorResponse status headers body ->
+--           ErrorResponse status (newHeader : headers) body
+--
+-- -- | Construct a response in the event of an error. These are /not/ tracked
+-- -- by the API type and are therefore free to return whatever they like.
+-- errorResponse :: HTTP.Status -> [HTTP.Header] -> Maybe Sl.ByteString -> Response NonStandard h b
+-- errorResponse = ErrorResponse
+--
+-- -- | If a response type is complete defined by its implementation then
+-- -- applying 'resorted' to it will future proof it against reorderings
+-- -- of headers. If the response type is not completely inferrable, however,
+-- -- then this will require manual annotations of the "pre-sorted" response.
+-- resortHeaders :: RecordIso headers headers' => Response e headers body -> Response e headers' body
+-- resortHeaders r =
+--   case r of
+--     Response status secretHeaders headers body ->
+--       Response status secretHeaders (reorder headers) body
+--     EmptyResponse status secretHeaders headers ->
+--       EmptyResponse status secretHeaders (reorder headers)
+--     ErrorResponse s h b -> ErrorResponse s h b
+--
+-- -- | Used primarily for implementing @HEAD@ request automatically.
+-- deleteBody :: Response e headers body -> Response e headers 'Empty
+-- deleteBody r =
+--   case r of
+--     Response status secretHeaders headers _ ->
+--       EmptyResponse status secretHeaders headers
+--     EmptyResponse{} -> r
+--     ErrorResponse s h _ -> ErrorResponse s h Nothing

--- a/src/Serv/Internal/Server/Response.hs
+++ b/src/Serv/Internal/Server/Response.hs
@@ -39,6 +39,12 @@ data SomeResponse (alts :: [Alternative Nat Symbol *]) where
     :: HTTP.Status -> [HTTP.Header] -> Maybe Sl.ByteString
     -> SomeResponse alts
 
+-- TODO: We need more than just this proof: we need a path into the list!
+-- Without this we cannot recover constraints placed on the response "from
+-- the outside"
+
+-- | While a response is constructed using other means, the response is
+-- finalized here. This is essential for typing purposes alone.
 respond
   :: (Elem (Responding code hdrs body) alts ~ True, Monad m)
   => Response code hdrs body -> m (SomeResponse alts)
@@ -53,6 +59,7 @@ respondExceptionally = NonStandardResponse
 emptyResponse :: Sing c -> Response c '[] 'Empty
 emptyResponse _status = emptyResponse'
 
+-- An 'emptyResponse'' returns the provided status message with no body or headers
 emptyResponse' :: Response c '[] 'Empty
 emptyResponse' = EmptyResponse [] Nil
 

--- a/src/Serv/Internal/StatusCode.hs
+++ b/src/Serv/Internal/StatusCode.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Module defining a set of types corresponding to HTTP status codes
+-- along with their singleton values. Only the most common codes are
+-- supported by name, although fully custom codes are generally supported.
+module Serv.Internal.StatusCode where
+
+import Data.Singletons
+import Data.Singletons.TH
+import GHC.TypeLits
+
+singletons
+  [d|
+    data StatusCode code
+
+      ---- Custom codes
+
+      = CustomStatus code
+        -- ^ Inject an arbitatry code number as a status code.
+
+      ---- 1xx Informational
+
+      | Continue
+      | SwitchingProtocols
+
+      ---- 2xx Success
+
+      | Ok
+      | Created
+      | Accepted
+      | NonAuthoritiveInformation
+      | NoContent
+      | ResetContent
+      | PartialContent
+      | IMUsed
+
+      ---- 3xx Redirection
+
+      | MultipleChoices
+      | MovedPermanently
+      | Found
+      | SeeOther
+      | NotModified
+      | TemporaryRedirect
+      | PermanentRedirect
+
+      ---- 4xx Client Error
+
+      | BadRequest
+      | Unauthorized
+      | PaymentRequired
+      | Forbidden
+      | NotFound
+      | MethodNotAllowed
+      | NotAcceptable
+      | ProxyAuthenticationRequired
+      | RequestTimeout
+      | Conflict
+      | Gone
+      | LengthRequired
+      | PreconditionFailed
+      | PayloadTooLarge
+      | RequestURITooLong
+      | UnsupportedMediaType
+      | RequestedRangeNotSatisfiable
+      | ExpectationFailed
+      | MisdirectedRequest
+      | UnprocessableEntity
+      | Locked
+      | FailedDependency
+      | UpgradeRequired
+      | PreconditionRequired
+      | TooManyRequests
+      | RequestHeaderFieldsTooLarge
+      | UnavailableForLegalReasons
+
+      ---- 5xx Server Error
+
+      | InternalServerError
+      | NotImplemented
+      | BadGateway
+      | ServiceUnavailable
+      | GatewayTimeout
+      | HTTPVersionNotSupported
+      | VariantAlsoNegotiates
+      | InsufficientStorage
+      | LoopDetected
+      | NotExtended
+      | NetworkAuthenticationRequired
+
+  |]
+
+deriving instance Show a => Show (StatusCode a)
+deriving instance Read a => Read (StatusCode a)
+deriving instance Eq a => Eq (StatusCode a)
+deriving instance Ord a => Ord (StatusCode a)
+deriving instance Functor StatusCode
+
+type CustomStatus code = 'CustomStatus code
+type Continue = 'Continue
+type SwitchingProtocols = 'SwitchingProtocols
+type Ok = 'Ok
+type Created = 'Created
+type Accepted = 'Accepted
+type NonAuthoritiveInformation = 'NonAuthoritiveInformation
+type NoContent = 'NoContent
+type ResetContent = 'ResetContent
+type PartialContent = 'PartialContent
+type IMUsed = 'IMUsed
+type MovedPermanently = 'MovedPermanently
+type Found = 'Found
+type SeeOther = 'SeeOther
+type NotModified = 'NotModified
+type TemporaryRedirect = 'TemporaryRedirect
+type PermanentRedirect = 'PermanentRedirect
+type Unauthorized = 'Unauthorized
+type PaymentRequired = 'PaymentRequired
+type Forbidden = 'Forbidden
+type NotFound = 'NotFound
+type MethodNotAllowed = 'MethodNotAllowed
+type NotAcceptable = 'NotAcceptable
+type ProxyAuthenticationRequired = 'ProxyAuthenticationRequired
+type RequestTimeout = 'RequestTimeout
+type Conflict = 'Conflict
+type Gone = 'Gone
+type LengthRequired = 'LengthRequired
+type PreconditionFailed = 'PreconditionFailed
+type PayloadTooLarge = 'PayloadTooLarge
+type RequestURITooLong = 'RequestURITooLong
+type UnsupportedMediaType = 'UnsupportedMediaType
+type RequestedRangeNotSatisfiable = 'RequestedRangeNotSatisfiable
+type ExpectationFailed = 'ExpectationFailed
+type MisdirectedRequest = 'MisdirectedRequest
+type UnprocessableEntity = 'UnprocessableEntity
+type Locked = 'Locked
+type FailedDependency = 'FailedDependency
+type UpgradeRequired = 'UpgradeRequired
+type PreconditionRequired = 'PreconditionRequired
+type TooManyRequests = 'TooManyRequests
+type RequestHeaderFieldsTooLarge = 'RequestHeaderFieldsTooLarge
+type UnavailableForLegalReasons = 'UnavailableForLegalReasons
+type NotImplemented = 'NotImplemented
+type BadGateway = 'BadGateway
+type ServiceUnavailable = 'ServiceUnavailable
+type GatewayTimeout = 'GatewayTimeout
+type HTTPVersionNotSupported = 'HTTPVersionNotSupported
+type VariantAlsoNegotiates = 'VariantAlsoNegotiates
+type InsufficientStorage = 'InsufficientStorage
+type LoopDetected = 'LoopDetected
+type NotExtended = 'NotExtended
+type NetworkAuthenticationRequired = 'NetworkAuthenticationRequired
+
+statusCode :: forall (c :: StatusCode Nat) . Sing c -> StatusCode Integer
+statusCode = fromSing
+
+code :: StatusCode Integer -> Integer
+code c =
+  case c of
+    CustomStatus code -> code
+
+    Continue -> 100
+    SwitchingProtocols -> 101
+
+    Ok -> 200
+    Created -> 201
+    Accepted -> 202
+    NonAuthoritiveInformation -> 203
+    NoContent -> 204
+    ResetContent -> 205
+    PartialContent -> 206
+    IMUsed -> 226
+
+    MultipleChoices -> 300
+    MovedPermanently -> 301
+    Found -> 302
+    SeeOther -> 303
+    NotModified -> 304
+    TemporaryRedirect -> 307
+    PermanentRedirect -> 308
+
+    BadRequest -> 400
+    Unauthorized -> 401
+    PaymentRequired -> 402
+    Forbidden -> 403
+    NotFound -> 404
+    MethodNotAllowed -> 405
+    NotAcceptable -> 406
+    ProxyAuthenticationRequired -> 407
+    RequestTimeout -> 408
+    Conflict -> 409
+    Gone -> 410
+    LengthRequired -> 411
+    PreconditionFailed -> 412
+    PayloadTooLarge -> 413
+    RequestURITooLong -> 414
+    UnsupportedMediaType -> 415
+    RequestedRangeNotSatisfiable -> 416
+    ExpectationFailed -> 417
+    MisdirectedRequest -> 421
+    UnprocessableEntity -> 422
+    Locked -> 423
+    FailedDependency -> 424
+    UpgradeRequired -> 426
+    PreconditionRequired -> 428
+    TooManyRequests -> 429
+    RequestHeaderFieldsTooLarge -> 431
+    UnavailableForLegalReasons -> 451
+
+    InternalServerError -> 500
+    NotImplemented -> 501
+    BadGateway -> 502
+    ServiceUnavailable -> 503
+    GatewayTimeout -> 504
+    HTTPVersionNotSupported -> 505
+    VariantAlsoNegotiates -> 506
+    InsufficientStorage -> 507
+    LoopDetected -> 508
+    NotExtended -> 510
+    NetworkAuthenticationRequired -> 511
+

--- a/src/Serv/Internal/StatusCode.hs
+++ b/src/Serv/Internal/StatusCode.hs
@@ -163,8 +163,8 @@ type NetworkAuthenticationRequired = 'NetworkAuthenticationRequired
 statusCode :: forall (c :: StatusCode Nat) . Sing c -> StatusCode Integer
 statusCode = fromSing
 
-code :: StatusCode Integer -> Integer
-code c =
+codeNum :: StatusCode Integer -> Integer
+codeNum c =
   case c of
     CustomStatus int -> int
 

--- a/src/Serv/Internal/StatusCode.hs
+++ b/src/Serv/Internal/StatusCode.hs
@@ -16,10 +16,7 @@
 -- supported by name, although fully custom codes are generally supported.
 module Serv.Internal.StatusCode where
 
-import           Data.Singletons
 import           Data.Singletons.TH
-import           Data.Singletons.TypeLits
-import           GHC.TypeLits
 import qualified Network.HTTP.Types.Status as S
 
 singletons
@@ -152,6 +149,7 @@ type PreconditionRequired = 'PreconditionRequired
 type TooManyRequests = 'TooManyRequests
 type RequestHeaderFieldsTooLarge = 'RequestHeaderFieldsTooLarge
 type UnavailableForLegalReasons = 'UnavailableForLegalReasons
+type InternalServerError = 'InternalServerError
 type NotImplemented = 'NotImplemented
 type BadGateway = 'BadGateway
 type ServiceUnavailable = 'ServiceUnavailable

--- a/src/Serv/Internal/StatusCode.hs
+++ b/src/Serv/Internal/StatusCode.hs
@@ -166,7 +166,7 @@ statusCode = fromSing
 code :: StatusCode Integer -> Integer
 code c =
   case c of
-    CustomStatus code -> code
+    CustomStatus int -> int
 
     Continue -> 100
     SwitchingProtocols -> 101

--- a/src/Serv/Internal/StatusCode.hs
+++ b/src/Serv/Internal/StatusCode.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
@@ -15,9 +16,11 @@
 -- supported by name, although fully custom codes are generally supported.
 module Serv.Internal.StatusCode where
 
-import Data.Singletons
-import Data.Singletons.TH
-import GHC.TypeLits
+import           Data.Singletons
+import           Data.Singletons.TH
+import           Data.Singletons.TypeLits
+import           GHC.TypeLits
+import qualified Network.HTTP.Types.Status as S
 
 singletons
   [d|
@@ -160,71 +163,68 @@ type LoopDetected = 'LoopDetected
 type NotExtended = 'NotExtended
 type NetworkAuthenticationRequired = 'NetworkAuthenticationRequired
 
-statusCode :: forall (c :: StatusCode Nat) . Sing c -> StatusCode Integer
-statusCode = fromSing
-
-codeNum :: StatusCode Integer -> Integer
-codeNum c =
+httpStatus :: StatusCode Integer -> S.Status
+httpStatus c =
   case c of
-    CustomStatus int -> int
+    CustomStatus int -> S.mkStatus (fromInteger int) ""
 
-    Continue -> 100
-    SwitchingProtocols -> 101
+    Continue -> S.status100
+    SwitchingProtocols -> S.status101
 
-    Ok -> 200
-    Created -> 201
-    Accepted -> 202
-    NonAuthoritiveInformation -> 203
-    NoContent -> 204
-    ResetContent -> 205
-    PartialContent -> 206
-    IMUsed -> 226
+    Ok -> S.status200
+    Created -> S.status201
+    Accepted -> S.status202
+    NonAuthoritiveInformation -> S.status203
+    NoContent -> S.status204
+    ResetContent -> S.status205
+    PartialContent -> S.status206
+    IMUsed -> S.mkStatus 226 "IM Used"
 
-    MultipleChoices -> 300
-    MovedPermanently -> 301
-    Found -> 302
-    SeeOther -> 303
-    NotModified -> 304
-    TemporaryRedirect -> 307
-    PermanentRedirect -> 308
+    MultipleChoices -> S.status300
+    MovedPermanently -> S.status301
+    Found -> S.status302
+    SeeOther -> S.status303
+    NotModified -> S.status304
+    TemporaryRedirect -> S.status307
+    PermanentRedirect -> S.status308
 
-    BadRequest -> 400
-    Unauthorized -> 401
-    PaymentRequired -> 402
-    Forbidden -> 403
-    NotFound -> 404
-    MethodNotAllowed -> 405
-    NotAcceptable -> 406
-    ProxyAuthenticationRequired -> 407
-    RequestTimeout -> 408
-    Conflict -> 409
-    Gone -> 410
-    LengthRequired -> 411
-    PreconditionFailed -> 412
-    PayloadTooLarge -> 413
-    RequestURITooLong -> 414
-    UnsupportedMediaType -> 415
-    RequestedRangeNotSatisfiable -> 416
-    ExpectationFailed -> 417
-    MisdirectedRequest -> 421
-    UnprocessableEntity -> 422
-    Locked -> 423
-    FailedDependency -> 424
-    UpgradeRequired -> 426
-    PreconditionRequired -> 428
-    TooManyRequests -> 429
-    RequestHeaderFieldsTooLarge -> 431
-    UnavailableForLegalReasons -> 451
+    BadRequest -> S.status400
+    Unauthorized -> S.status401
+    PaymentRequired -> S.status402
+    Forbidden -> S.status403
+    NotFound -> S.status404
+    MethodNotAllowed -> S.status405
+    NotAcceptable -> S.status406
+    ProxyAuthenticationRequired -> S.status407
+    RequestTimeout -> S.status408
+    Conflict -> S.status409
+    Gone -> S.status410
+    LengthRequired -> S.status411
+    PreconditionFailed -> S.status412
+    PayloadTooLarge -> S.status413
+    RequestURITooLong -> S.status414
+    UnsupportedMediaType -> S.status415
+    RequestedRangeNotSatisfiable -> S.status416
+    ExpectationFailed -> S.status417
+    MisdirectedRequest -> S.mkStatus 421 "Misdirected Request"
+    UnprocessableEntity -> S.mkStatus 422 "Unprocessable Entity"
+    Locked -> S.mkStatus 423 "Locked"
+    FailedDependency -> S.mkStatus 424 "Failed Dependency"
+    UpgradeRequired -> S.mkStatus 426 "Upgrade Required"
+    PreconditionRequired -> S.status428
+    TooManyRequests -> S.status429
+    RequestHeaderFieldsTooLarge -> S.status431
+    UnavailableForLegalReasons -> S.mkStatus 451 "Unavailable for Legal Reasons"
 
-    InternalServerError -> 500
-    NotImplemented -> 501
-    BadGateway -> 502
-    ServiceUnavailable -> 503
-    GatewayTimeout -> 504
-    HTTPVersionNotSupported -> 505
-    VariantAlsoNegotiates -> 506
-    InsufficientStorage -> 507
-    LoopDetected -> 508
-    NotExtended -> 510
-    NetworkAuthenticationRequired -> 511
+    InternalServerError -> S.status500
+    NotImplemented -> S.status501
+    BadGateway -> S.status502
+    ServiceUnavailable -> S.status503
+    GatewayTimeout -> S.status504
+    HTTPVersionNotSupported -> S.status505
+    VariantAlsoNegotiates -> S.mkStatus 506 "Variant Also Negotiates"
+    InsufficientStorage -> S.mkStatus 507 "Insufficient Storage"
+    LoopDetected -> S.mkStatus 508 "Loop Detected"
+    NotExtended -> S.mkStatus 510 "Not Extended"
+    NetworkAuthenticationRequired -> S.status511
 

--- a/src/Serv/Server.hs
+++ b/src/Serv/Server.hs
@@ -31,7 +31,6 @@ module Serv.Server (
     , Response
     , respond
     , emptyResponse
-    , errorResponse
     , withBody
     , withHeader
     , withQuietHeader

--- a/src/Serv/StatusCode.hs
+++ b/src/Serv/StatusCode.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DataKinds #-}
+
+module Serv.StatusCode (
+
+    StatusCode (..)
+
+  -- Singleton values
+
+  , Sing
+    ( SCustomStatus
+    , SContinue
+    , SSwitchingProtocols
+    , SOk
+    , SCreated
+    , SAccepted
+    , SNonAuthoritiveInformation
+    , SNoContent
+    , SResetContent
+    , SPartialContent
+    , SIMUsed
+    , SMovedPermanently
+    , SFound
+    , SSeeOther
+    , SNotModified
+    , STemporaryRedirect
+    , SPermanentRedirect
+    , SUnauthorized
+    , SPaymentRequired
+    , SForbidden
+    , SNotFound
+    , SMethodNotAllowed
+    , SNotAcceptable
+    , SProxyAuthenticationRequired
+    , SRequestTimeout
+    , SConflict
+    , SGone
+    , SLengthRequired
+    , SPreconditionFailed
+    , SPayloadTooLarge
+    , SRequestURITooLong
+    , SUnsupportedMediaType
+    , SRequestedRangeNotSatisfiable
+    , SExpectationFailed
+    , SMisdirectedRequest
+    , SUnprocessableEntity
+    , SLocked
+    , SFailedDependency
+    , SUpgradeRequired
+    , SPreconditionRequired
+    , STooManyRequests
+    , SRequestHeaderFieldsTooLarge
+    , SUnavailableForLegalReasons
+    , SNotImplemented
+    , SBadGateway
+    , SServiceUnavailable
+    , SGatewayTimeout
+    , SHTTPVersionNotSupported
+    , SVariantAlsoNegotiates
+    , SInsufficientStorage
+    , SLoopDetected
+    , SNotExtended
+    , SNetworkAuthenticationRequired
+    )
+
+    -- Type synonyms (so as to avoid unneeded quotes)
+
+    , CustomStatus
+    , Continue
+    , SwitchingProtocols
+    , Ok
+    , Created
+    , Accepted
+    , NonAuthoritiveInformation
+    , NoContent
+    , ResetContent
+    , PartialContent
+    , IMUsed
+    , MovedPermanently
+    , Found
+    , SeeOther
+    , NotModified
+    , TemporaryRedirect
+    , PermanentRedirect
+    , Unauthorized
+    , PaymentRequired
+    , Forbidden
+    , NotFound
+    , MethodNotAllowed
+    , NotAcceptable
+    , ProxyAuthenticationRequired
+    , RequestTimeout
+    , Conflict
+    , Gone
+    , LengthRequired
+    , PreconditionFailed
+    , PayloadTooLarge
+    , RequestURITooLong
+    , UnsupportedMediaType
+    , RequestedRangeNotSatisfiable
+    , ExpectationFailed
+    , MisdirectedRequest
+    , UnprocessableEntity
+    , Locked
+    , FailedDependency
+    , UpgradeRequired
+    , PreconditionRequired
+    , TooManyRequests
+    , RequestHeaderFieldsTooLarge
+    , UnavailableForLegalReasons
+    , NotImplemented
+    , BadGateway
+    , ServiceUnavailable
+    , GatewayTimeout
+    , HTTPVersionNotSupported
+    , VariantAlsoNegotiates
+    , InsufficientStorage
+    , LoopDetected
+    , NotExtended
+    , NetworkAuthenticationRequired
+
+  ) where
+
+import           Data.Singletons                    (Sing)
+import           Serv.Internal.StatusCode

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Test where
+
+import GHC.Exts
+
+data Corec :: [*] -> * where
+  Here :: a -> Corec (a ': as)
+  There :: Corec as -> Corec (a ': as)
+
+type family AllShow (as :: [*]) :: Constraint where
+  AllShow '[] = ()
+  AllShow (a ': as) = (Show a, AllShow as)
+
+deriving instance AllShow as => Show (Corec as)
+
+class Ok a where
+  ok :: a -> ()
+
+instance Ok Bool where ok _ = ()
+instance Ok Int where ok _ = ()
+instance Ok String where ok _ = ()
+instance Ok () where ok _ = ()
+
+type family AllOk (a :: [*]) :: Constraint where
+  AllOk '[] = ()
+  AllOk (a ': as) = (Ok a, AllOk as)
+
+okCorec :: AllOk as => Corec as -> ()
+okCorec (Here a) = ok a
+okCorec (There next) = okCorec next
+
+class Inject as a where
+  inject :: a -> Corec as
+
+instance {-# OVERLAPPING #-} Inject (a ': as) a where
+  inject = Here
+
+instance Inject as a => Inject (x ': as) a where
+  inject = There . inject
+
+injected :: Corec [Bool, Int, String, ()]
+injected = inject ()
+
+isOk :: ()
+isOk = okCorec injected

--- a/test/Examples/Ex1.hs
+++ b/test/Examples/Ex1.hs
@@ -25,13 +25,16 @@ type JSONBody = HasBody '[ Ct.JSON ] [Int]
 type TheApi
   = Endpoint ()
     '[ Method GET
-       '[ Sc.Ok ::: Respond '[ H.CacheControl ::: RawText ] RawBody
+       '[ Sc.Ok :::
+          Respond '[ H.CacheControl ::: RawText ] RawBody
         ]
      , Method PUT
-       '[ Sc.Ok ::: Respond '[ H.CacheControl ::: RawText ] JSONBody
+       '[ Sc.Ok :::
+          Respond '[ H.CacheControl ::: RawText ] JSONBody
         ]
      , Method DELETE
-       '[ Sc.InternalServerError ::: Respond '[] RawBody
+       '[ Sc.InternalServerError :::
+          Respond '[] RawBody
         ]
      ]
 

--- a/test/Examples/Ex1.hs
+++ b/test/Examples/Ex1.hs
@@ -5,27 +5,37 @@
 
 module Examples.Ex1 where
 
-import           Data.Function    ((&))
+import           Data.Function            ((&))
 import           Data.String
-import           Data.Text        (Text)
-import qualified Network.Wai      as Wai
-import qualified Network.Wai.Test as T
+import           Data.Text                (Text)
+import qualified Network.Wai              as Wai
+import qualified Network.Wai.Test         as T
 import           Serv.Api
 import           Serv.Common
-import qualified Serv.ContentType as Ct
-import qualified Serv.Header      as H
+import qualified Serv.ContentType         as Ct
+import qualified Serv.Header              as H
+import qualified Serv.Internal.StatusCode as Sc
 import           Serv.Server
 import           Test.Tasty
-import qualified Test.Tasty.HUnit as Hu
+import qualified Test.Tasty.HUnit         as Hu
 
 type RawBody = HasBody '[ Ct.TextPlain ] Text
 type JSONBody = HasBody '[ Ct.JSON ] [Int]
 
 type TheApi
   = Endpoint ()
-    '[ Method GET '[ 'H.CacheControl ::: RawText ] RawBody
-     , Method PUT '[ 'H.CacheControl ::: RawText ] JSONBody
-     , Method DELETE '[] Empty
+    '[ Method GET
+       '[ Responding Sc.Ok
+          '[ 'H.CacheControl ::: RawText ] RawBody
+        ]
+     , Method PUT
+       '[ Responding Sc.Ok
+          '[ 'H.CacheControl ::: RawText ] JSONBody
+        ]
+     , Method DELETE
+       '[ Responding Sc.InternalServerError
+          '[] RawBody
+        ]
      ]
 
 apiSing :: Sing TheApi
@@ -36,17 +46,18 @@ impl = get :<|> put :<|> delete :<|> MethodNotAllowed
   where
     get =
       respond
-      $ emptyResponse ok200
+      $ emptyResponse Sc.SOk
       & withHeader H.SCacheControl "foo"
       & withBody "Hello"
     put =
       respond
-      $ emptyResponse ok200
+      $ emptyResponse Sc.SOk
       & withHeader H.SCacheControl "foo"
       & withBody [1, 2, 3]
     delete =
       respond
-      $ errorResponse status500 [] (Just "Server error")
+      $ emptyResponse Sc.SInternalServerError
+      & withBody "Server error"
 
 
 theServer :: Server IO

--- a/test/Examples/Ex1.hs
+++ b/test/Examples/Ex1.hs
@@ -25,16 +25,13 @@ type JSONBody = HasBody '[ Ct.JSON ] [Int]
 type TheApi
   = Endpoint ()
     '[ Method GET
-       '[ Responding Sc.Ok
-          '[ 'H.CacheControl ::: RawText ] RawBody
+       '[ Sc.Ok ::: Respond '[ H.CacheControl ::: RawText ] RawBody
         ]
      , Method PUT
-       '[ Responding Sc.Ok
-          '[ 'H.CacheControl ::: RawText ] JSONBody
+       '[ Sc.Ok ::: Respond '[ H.CacheControl ::: RawText ] JSONBody
         ]
      , Method DELETE
-       '[ Responding Sc.InternalServerError
-          '[] RawBody
+       '[ Sc.InternalServerError ::: Respond '[] RawBody
         ]
      ]
 

--- a/test/Examples/Ex2.hs
+++ b/test/Examples/Ex2.hs
@@ -42,7 +42,7 @@ impl _ifRange = get :<|> delete :<|> MethodNotAllowed
     get =
       respond
       $ emptyResponse Sc.SOk
-      & withHeader H.SXCsrfToken (RawText "some-csrf-token")
+      & withHeader H.SXCsrfToken "some-csrf-token"
       & withBody "Hello"
     delete =
       respond

--- a/test/Examples/Ex2.hs
+++ b/test/Examples/Ex2.hs
@@ -28,9 +28,9 @@ type TheApi
     Header H.IfRange (Maybe RawText) :>
     Endpoint ()
       '[ Method GET
-         '[ Responding Sc.Ok '[ H.XCsrfToken ::: RawText ] RawBody ]
+         '[ Sc.Ok ::: Respond '[ H.XCsrfToken ::: RawText ] RawBody ]
        , Method DELETE
-         '[ Responding Sc.NoContent '[] Empty ]
+         '[ Sc.NoContent ::: Respond '[] Empty ]
        ]
 
 apiProxy :: Sing TheApi


### PR DESCRIPTION
> Has ~~science~~ tel gone *too far*?

... Or not yet far enough.

---

```haskell
Method GET
  '[ Ok ::: Respond '[ (CacheControl, NominalDiffTime) ] (Body '[JSON] User)
   , NoContent ::: Respond '[ (CacheControl, NominalDiffTime) ] NoBody
     -- we're not validating this matches the code semantics... at least not TODAY!   
   ]
```

---

By all accounts this is probably a terrible, horrible, really no good idea, BUT I actually think it's quite important, too. Status codes are a supremely important part of an endpoint and enable us to talk about error handling in a "sane" way. Compare this with the sort of `Either` tricks you'd normally have to pull if you want to talk about an endpoint that can return errors in certain circumstances. 

Or what happens when sometimes—*but only sometimes*—an endpoint returns `204 No Content`. You'll look kind of foolish with your `Body` encodings there. Should it be a `Maybe User`? Or something more domain specific like `MayBeNoContentButOtherwiseIt'sTotallyA User`?

So in some weird way this is the only sane way to encode these variations! It provides *exactly* the kind of place we'd like to handle status code variations. And as long as we're going in whole hog to offer such a "dependently typed" API definition... well, why not go in truly whole hog?

---

## Goals

- [x] Correspond `StatusCode`s to response values using `(:::)` to indicate the nature of the map (extend `Body` to capture headers in order to handle this, I think)
- [x] Determine how `StatusCode`s should be imported
- [x] Ensure it works on `--pedantic`
